### PR TITLE
Fix settings updater to avoid stale state overwrites

### DIFF
--- a/src/components/AssemblyExporter.tsx
+++ b/src/components/AssemblyExporter.tsx
@@ -61,11 +61,13 @@ function useSettings() {
   });
 
   const update = (patch: Partial<AppSettings>) => {
-    const next = { ...settings, ...patch };
-    setSettings(next);
-    localStorage.setItem("assemblyExporterSettings", JSON.stringify(next));
-    localStorage.setItem("sheet_webapp", next.scriptUrl || "");
-    localStorage.setItem("sheet_secret", next.secret || "");
+    setSettings((prev) => {
+      const next = { ...prev, ...patch };
+      localStorage.setItem("assemblyExporterSettings", JSON.stringify(next));
+      localStorage.setItem("sheet_webapp", next.scriptUrl || "");
+      localStorage.setItem("sheet_secret", next.secret || "");
+      return next;
+    });
   };
 
   return [settings, update] as const;


### PR DESCRIPTION
## Summary
- update the settings helper to merge state changes using the latest values to avoid overwriting prior edits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a36cfce88329bd14cb802dc0f9c6